### PR TITLE
Add sample Android project

### DIFF
--- a/HelloAndroid/.gitignore
+++ b/HelloAndroid/.gitignore
@@ -1,0 +1,6 @@
+*.iml
+.gradle/
+/local.properties
+/.idea/
+/build/
+app/build/

--- a/HelloAndroid/README.md
+++ b/HelloAndroid/README.md
@@ -1,0 +1,15 @@
+# HelloAndroid
+
+This is a minimal Android application written in Kotlin. It targets Android 9 (API 28) and newer versions up to the latest available compile SDK.
+
+## Project Structure
+- `app/build.gradle` – Android module configuration
+- `MainActivity.kt` – activity displaying a simple "Hello Android" message
+
+To build the project with Gradle:
+
+```bash
+./gradlew assembleDebug
+```
+
+An Android SDK is required to compile the project.

--- a/HelloAndroid/app/build.gradle
+++ b/HelloAndroid/app/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.hello'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'com.example.hello'
+        minSdk 28
+        targetSdk 34
+        versionCode 1
+        versionName '1.0'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+}

--- a/HelloAndroid/app/proguard-rules.pro
+++ b/HelloAndroid/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Proguard rules

--- a/HelloAndroid/app/src/main/AndroidManifest.xml
+++ b/HelloAndroid/app/src/main/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.hello">
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.HelloAndroid">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/HelloAndroid/app/src/main/java/com/example/hello/MainActivity.kt
+++ b/HelloAndroid/app/src/main/java/com/example/hello/MainActivity.kt
@@ -1,0 +1,11 @@
+package com.example.hello
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+}

--- a/HelloAndroid/app/src/main/res/layout/activity_main.xml
+++ b/HelloAndroid/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hello Android" />
+</LinearLayout>

--- a/HelloAndroid/app/src/main/res/values/colors.xml
+++ b/HelloAndroid/app/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<resources>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+    <color name="teal_700">#018786</color>
+    <color name="white">#FFFFFF</color>
+    <color name="black">#000000</color>
+</resources>

--- a/HelloAndroid/app/src/main/res/values/strings.xml
+++ b/HelloAndroid/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">HelloAndroid</string>
+</resources>

--- a/HelloAndroid/app/src/main/res/values/themes.xml
+++ b/HelloAndroid/app/src/main/res/values/themes.xml
@@ -1,0 +1,11 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.HelloAndroid" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorOnPrimary">@color/white</item>
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="colorSecondaryVariant">@color/teal_700</item>
+        <item name="colorOnSecondary">@color/black</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@color/purple_700</item>
+    </style>
+</resources>

--- a/HelloAndroid/build.gradle
+++ b/HelloAndroid/build.gradle
@@ -1,0 +1,16 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.4.1'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/HelloAndroid/gradle.properties
+++ b/HelloAndroid/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx1g
+android.useAndroidX=true
+android.enableJetifier=true

--- a/HelloAndroid/settings.gradle
+++ b/HelloAndroid/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'HelloAndroid'
+include ':app'


### PR DESCRIPTION
## Summary
- add a HelloAndroid sample
- include basic activity and Gradle build scripts

## Testing
- `gradle help --no-daemon -q` *(fails: Plugin id 'org.jetbrains.kotlin.android' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_685187fb0af08332b1656e24d08929d1

## Summary by Sourcery

Add a minimal HelloAndroid sample project

New Features:
- Introduce a HelloAndroid Kotlin application with MainActivity, layout, and resources

Build:
- Add project-level and module-level Gradle build scripts configured for Android

Documentation:
- Add README.md with project structure and build instructions

Chores:
- Add .gitignore, gradle.properties, settings.gradle, and ProGuard rules